### PR TITLE
Updated DB to include stock_limit on Component

### DIFF
--- a/DB/init.sql
+++ b/DB/init.sql
@@ -7,6 +7,7 @@ CREATE TABLE `BarInventory`.`Component` (
   `quantity` float NOT NULL,
   `size` float,
   `cost` float,
+  `stock_limit` float,
   PRIMARY KEY (`component_id`)
 );
 

--- a/DBSCHEMA.md
+++ b/DBSCHEMA.md
@@ -23,6 +23,7 @@ Component {
     quantity float
     size float
     cost float
+    stock_limit float
 }
 
 Shelf {


### PR DESCRIPTION
In this MR, I updated the database schema to include a stock_limit float field for the Component table. This will allow users to set an amount of the component that they deem is "in-stock" for their bar and allow the backend to calculate how much money it would take to restock the bar.

Closes #16

Story points: 0, This story took me under 10 minutes to complete.